### PR TITLE
Add contributors list and bump for 2.0.0 release

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,30 @@
+{
+  "projectName": "pino-logdna",
+  "projectOwner": "logdna",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "digitalmio",
+      "name": "Maciej Ziehlke",
+      "avatar_url": "https://avatars.githubusercontent.com/u/226042?v=4",
+      "profile": "https://www.linkedin.com/in/ziehlke/",
+      "contributions": [
+        "original"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "types": {
+    "original": {
+      "symbol": "⭐",
+      "description": "Original author/maintainer"
+    }
+  }
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,18 @@
       "contributions": [
         "original"
       ]
+    },
+    {
+      "login": "mdeltito",
+      "name": "Mike Del Tito",
+      "avatar_url": "https://avatars.githubusercontent.com/u/69520?v=4",
+      "profile": "https://github.com/mdeltito",
+      "contributions": [
+        "code",
+        "doc",
+        "example",
+        "tool"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # pino-logdna
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 > Transport pino logs to LogDNA
 
@@ -87,6 +90,26 @@ Options:
       --index-meta [false]        Controls whether meta data for each message is searchable
   -p, --proxy                     The full URL of an http or https proxy to pass through
 ```
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://www.linkedin.com/in/ziehlke/"><img src="https://avatars.githubusercontent.com/u/226042?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Maciej Ziehlke</b></sub></a><br /><a href="#original-digitalmio" title="Original author/maintainer">⭐</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pino-logdna
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 > Transport pino logs to LogDNA
@@ -101,6 +101,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tr>
     <td align="center"><a href="https://www.linkedin.com/in/ziehlke/"><img src="https://avatars.githubusercontent.com/u/226042?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Maciej Ziehlke</b></sub></a><br /><a href="#original-digitalmio" title="Original author/maintainer">⭐</a></td>
+    <td align="center"><a href="https://github.com/mdeltito"><img src="https://avatars.githubusercontent.com/u/69520?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mike Del Tito</b></sub></a><br /><a href="https://github.com/logdna/pino-logdna/commits?author=mdeltito" title="Code">💻</a> <a href="https://github.com/logdna/pino-logdna/commits?author=mdeltito" title="Documentation">📖</a> <a href="#example-mdeltito" title="Examples">💡</a> <a href="#tool-mdeltito" title="Tools">🔧</a></td>
   </tr>
 </table>
 

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "execa": "^4.1.0",
     "nock": "^13.0.7",
     "pino": "^6.11.0",
-    "semantic-release": "^17.3.8",
-    "semantic-release-config-logdna": "^1.0.0",
+    "semantic-release": "^17.3.9",
+    "semantic-release-config-logdna": "^1.1.0",
     "tap": "^14.11.0",
     "tap-parser": "^10.1.0",
     "tap-xunit": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -45,12 +45,6 @@
     "name": "LogDNA, Inc.",
     "email": "help@logdna.com"
   },
-  "contributors": [
-    {
-      "name": "Mike Del Tito",
-      "email": "mike.deltito@logdna.com"
-    }
-  ],
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/logdna/pino-logdna/issues"


### PR DESCRIPTION
**chore(deps): update semantic-release deps**

Updates to the latest semantic-release-config-logdna
which supports breaking change identifiers in the commit
type.

---

**docs: add @digitalmio as a contributor**

Adding @digitalmio as a contributor of the original
version of `pino-logdna`, and for kindly transferring
maintainership of the package to LogDNA

--- 

**docs!: add @mdeltito as a contributor**

BREAKING CHANGE:

Adding @mdeltito as a contributor for release of 2.0.0 of
this package.