### PR TITLE
fix: data logs being dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,19 @@ log.info('Happy Logging!')
 #### Options
 
 This transport uses [`@logdna/logger`][] under the hood, and most options are exposed
-through `pino-logdna`. 
+through `pino-logdna`.
 
-For a full list, please see the [`createLogger` options][]
+For a full list, please see the [`createLogger` options][].
+
+An additional option is supported by `pino-logdna`:
+
++ `emptyMessage` `<String>` - When logging an object without a message,
+e.g. `log.info({ some: 'data' })`, the value of this option will be used
+for the outgoing message. Default: `'<data log>'`.
 
 ### Legacy Transport
 
-Usage as a legacy transport is still supported. The minimal configuration requires only 
+Usage as a legacy transport is still supported. The minimal configuration requires only
 your LogDNA ingestion key:
 
 ```bash
@@ -73,7 +79,8 @@ Options for the CLI are the kebab-case equivalent of the [`@logdna/logger`][] op
 Options:
   -v, --version                   Show version
   -h, --help                      Show usage information
-  -m, --message-key [msg]         The field in the `pino` used as the display line in LogDNA 
+  -m, --message-key [msg]         The field in the `pino` used as the display line in LogDNA
+  -e, --empty-message [msg]       String value to use when no "message" property if found
 
 @logdna/logger Options:
       --key                       *REQUIRED* Your ingestion key

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,12 +28,14 @@ const noptions = {
 , 'index-meta': Boolean
 , 'proxy': url
 , 'message-key': String
+, 'empty-message': String
 }
 
 const nshort = {
   h: ['--help']
 , v: ['--version']
 , m: ['--message-key']
+, e: ['--empty-message']
 , t: ['--tag']
 , T: ['--timeout']
 , H: ['--hostname']

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -1,15 +1,16 @@
 pino-logdna - Pino transport for sending logs to LogDNA
 
-  Usage: 
+  Usage:
     pino-logdna --key "YOUR INGESTION KEY" [options]
-  
-  Example: 
+
+  Example:
     ./my-app | pino-logdna --key "YOUR INGESTION KEY" --env staging --tag foo --tag bar
-  
+
   Options:
     -v, --version                   Show version
     -h, --help                      Show usage information
-    -m, --message-key [msg]         The field in the `pino` used as the display line in LogDNA 
+    -m, --message-key [msg]         The field in the `pino` used as the display line in LogDNA
+    -e, --empty-message [msg]       String value to use when no "message" property if found
 
   @logdna/logger Options:
         --key                       *REQUIRED* Your ingestion key

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -21,6 +21,7 @@ function logdnaStream(options) {
     key
   , onError
   , messageKey = 'msg'
+  , emptyMessage = '<data log>'
   , ...logger_opts
   } = options
 
@@ -54,7 +55,7 @@ function logdnaStream(options) {
       , timestamp
       }
 
-      logger.log(message, opts)
+      logger.log(message || emptyMessage, opts)
       cb(null)
     }
   , destroy(err, cb) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "tap",
     "test:ci": "tools/test-ci.sh",
+    "test:watch": "tap --no-coverage-report -w",
     "pretest": "npm run lint",
     "pretest:ci": "npm run lint",
     "release": "semantic-release"

--- a/test/fixtures/logs
+++ b/test/fixtures/logs
@@ -5,7 +5,7 @@
 
 non-pino output
 {malformed json}
-{"level":30,"pid":34442,"obj":42,"b":2,"note":"does not have message or timestamp"}
+{"level":30,"pid":34442,"obj":42,"b":2,"hostname":"logs.local","note":"does not have message or timestamp"}
 
 {"pid":34442,"hostname":"logs.local","msg":"no timestamp or level"}
 {"level":"40","time":1612675898239,"pid":34442,"hostname":"logs.local","obj":42,"b":2,"msg":"hello world with an invalid level"}


### PR DESCRIPTION
Pino's log method signature is `method([mergingObject], [message])`, e.g. `log.info({}, 'foo')` (https://getpino.io/#/docs/api?id=logging-method-parameters). This means Pino supports:

```js
log.info({ some: 'data'})
```

However, if a log like that is attempted with `pino-logdna` it will be rejected by the ingestor because it does not contain a message-like property. This PR solves it by adding a default message in such cases.