### PR TITLE
chore: Upgrade `@logdna/logger`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/logdna/pino-logdna#readme",
   "dependencies": {
-    "@logdna/logger": "^2.4.1",
+    "@logdna/logger": "^2.6.8",
     "nopt": "^5.0.0",
     "pino-abstract-transport": "^0.5.0"
   },


### PR DESCRIPTION
Upgrade `logdna/logger` in order to fix the security issue https://github.com/advisories/GHSA-wf5p-g6vw-rhxx